### PR TITLE
Fix write_cstr overflow check

### DIFF
--- a/arma-rs-proc/src/lib.rs
+++ b/arma-rs-proc/src/lib.rs
@@ -54,12 +54,11 @@ pub fn arma(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #[no_mangle]
-        pub unsafe extern #extern_type fn #versionfn(output: *mut arma_rs_libc::c_char, size: arma_rs_libc::size_t)-> arma_rs_libc::c_int {
+        pub unsafe extern #extern_type fn #versionfn(output: *mut arma_rs_libc::c_char, size: arma_rs_libc::size_t) {
             #ext_init
             if let Some(ext) = &RV_EXTENSION {
                 arma_rs::write_cstr(ext.version().to_string(), output, size);
             }
-            0
         }
 
         #[no_mangle]

--- a/arma-rs-proc/src/lib.rs
+++ b/arma-rs-proc/src/lib.rs
@@ -54,11 +54,12 @@ pub fn arma(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #[no_mangle]
-        pub unsafe extern #extern_type fn #versionfn(output: *mut arma_rs_libc::c_char, size: arma_rs_libc::size_t) {
+        pub unsafe extern #extern_type fn #versionfn(output: *mut arma_rs_libc::c_char, size: arma_rs_libc::size_t) -> arma_rs_libc::c_int {
             #ext_init
             if let Some(ext) = &RV_EXTENSION {
                 arma_rs::write_cstr(ext.version().to_string(), output, size);
             }
+            0
         }
 
         #[no_mangle]

--- a/arma-rs/src/context.rs
+++ b/arma-rs/src/context.rs
@@ -7,19 +7,19 @@ use crate::{IntoArma, Value};
 /// Contains information about the current execution context
 pub struct Context {
     pub(crate) queue: Arc<SegQueue<(String, String, Option<Value>)>>,
-    buffer_len: usize,
+    buffer_size: usize,
 }
 
 impl Context {
     pub(crate) fn new(queue: Arc<SegQueue<(String, String, Option<Value>)>>) -> Self {
         Self {
             queue,
-            buffer_len: 0,
+            buffer_size: 0,
         }
     }
 
-    pub(crate) const fn with_buffer_size(mut self, buffer_len: usize) -> Self {
-        self.buffer_len = buffer_len;
+    pub(crate) const fn with_buffer_size(mut self, buffer_size: usize) -> Self {
+        self.buffer_size = buffer_size;
         self
     }
 
@@ -27,7 +27,11 @@ impl Context {
     /// Returns the length in bits of the output buffer.
     /// This is the maximum size of the data that can be returned by the extension.
     pub const fn buffer_len(&self) -> usize {
-        self.buffer_len
+        if self.buffer_size != 0 {
+            self.buffer_size - 1
+        } else {
+            0
+        }
     }
 
     /// Sends a callback into Arma
@@ -38,5 +42,22 @@ impl Context {
     {
         self.queue
             .push((name.to_string(), func.to_string(), Some(data.into())));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_buffer_len_zero() {
+        let ctx = Context::new(Arc::new(SegQueue::new()));
+        assert_eq!(ctx.buffer_len(), 0);
+    }
+
+    #[test]
+    fn context_buffer_len() {
+        let ctx = Context::new(Arc::new(SegQueue::new())).with_buffer_size(100);
+        assert_eq!(ctx.buffer_len(), 99);
     }
 }

--- a/arma-rs/src/context.rs
+++ b/arma-rs/src/context.rs
@@ -24,7 +24,7 @@ impl Context {
     }
 
     #[must_use]
-    /// Returns the length in bits of the output buffer.
+    /// Returns the length in bytes of the output buffer.
     /// This is the maximum size of the data that can be returned by the extension.
     pub const fn buffer_len(&self) -> usize {
         if self.buffer_size != 0 {

--- a/arma-rs/src/lib.rs
+++ b/arma-rs/src/lib.rs
@@ -263,7 +263,7 @@ mod tests {
     #[test]
     fn write_size_zero() {
         const BUF_SIZE: libc::size_t = 0;
-        let mut buf = [0i8; BUF_SIZE];
+        let mut buf = [0; BUF_SIZE];
         let result = unsafe { write_cstr("".to_string(), buf.as_mut_ptr(), BUF_SIZE) };
 
         assert_eq!(result, None);
@@ -272,53 +272,50 @@ mod tests {
     #[test]
     fn write_one() {
         const BUF_SIZE: libc::size_t = 1;
-        let mut buf = [0i8; BUF_SIZE];
+        let mut buf = [0; BUF_SIZE];
         let result = unsafe { write_cstr("".to_string(), buf.as_mut_ptr(), BUF_SIZE) };
 
         assert_eq!(result, Some(BUF_SIZE - 1));
-        assert_eq!(buf, ['\0'].map(|c| c as i8));
+        assert_eq!(buf, (b"\0").map(|c| c as i8));
     }
 
     #[test]
     fn write_half() {
         const BUF_SIZE: libc::size_t = 7;
-        let mut buf = [0i8; BUF_SIZE];
+        let mut buf = [0; BUF_SIZE];
         let result = unsafe { write_cstr("foo".to_string(), buf.as_mut_ptr(), BUF_SIZE) };
 
         assert_eq!(result, Some(3));
-        assert_eq!(
-            buf,
-            ['f', 'o', 'o', '\0', '\0', '\0', '\0'].map(|c| c as i8)
-        );
+        assert_eq!(buf, (b"foo\0\0\0\0").map(|c| c as i8));
     }
 
     #[test]
     fn write_full() {
         const BUF_SIZE: libc::size_t = 7;
-        let mut buf = [0i8; BUF_SIZE];
+        let mut buf = [0; BUF_SIZE];
         let result = unsafe { write_cstr("foobar".to_string(), buf.as_mut_ptr(), BUF_SIZE) };
 
         assert_eq!(result, Some(6));
-        assert_eq!(buf, ['f', 'o', 'o', 'b', 'a', 'r', '\0'].map(|c| c as i8));
+        assert_eq!(buf, (b"foobar\0").map(|c| c as i8));
     }
 
     #[test]
     fn write_overflow() {
         const BUF_SIZE: libc::size_t = 4;
-        let mut buf = [0i8; BUF_SIZE];
+        let mut buf = [0; BUF_SIZE];
         let result = unsafe { write_cstr("overflow".to_string(), buf.as_mut_ptr(), BUF_SIZE) };
 
         assert_eq!(result, None);
-        assert_eq!(buf, ['\0', '\0', '\0', '\0'].map(|c| c as i8));
+        assert_eq!(buf, [0; BUF_SIZE]);
     }
 
     #[test]
     fn write_overwrite() {
         const BUF_SIZE: libc::size_t = 4;
-        let mut buf = ['z', 'z', 'z', '\0'].map(|c| c as i8);
+        let mut buf = (b"zzz\0").map(|c| c as i8);
         let result = unsafe { write_cstr("a".to_string(), buf.as_mut_ptr(), BUF_SIZE) };
 
         assert_eq!(result, Some(1));
-        assert_eq!(buf, ['a', '\0', 'z', '\0'].map(|c| c as i8));
+        assert_eq!(buf, (b"a\0z\0").map(|c| c as i8));
     }
 }

--- a/arma-rs/src/lib.rs
+++ b/arma-rs/src/lib.rs
@@ -105,7 +105,7 @@ impl Extension {
             return 1;
         };
         self.group.handle(
-            self.context().with_buffer_size(size - 8),
+            self.context().with_buffer_size(size),
             &function,
             output,
             size,
@@ -239,19 +239,86 @@ impl ExtensionBuilder {
 /// This function is unsafe because it interacts with the C API.
 ///
 /// # Note
-/// This function assumes `buf_size` has already been subtracted by 8 bits to allow a null value at the end.
+/// This function assumes `buf_size` includes space for a single terminating zero byte at the end.
 pub unsafe fn write_cstr(
     string: String,
     ptr: *mut libc::c_char,
     buf_size: libc::size_t,
 ) -> Option<libc::size_t> {
     let cstr = std::ffi::CString::new(string).ok()?;
-    let cstr_bytes = cstr.as_bytes();
-    let len_to_copy = cstr_bytes.len();
-    if len_to_copy * 8 >= buf_size {
+    let len_to_copy = cstr.as_bytes().len();
+    if len_to_copy >= buf_size {
         return None;
     }
+
     ptr.copy_from(cstr.as_ptr(), len_to_copy);
     ptr.add(len_to_copy).write(0x00);
     Some(len_to_copy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_size_zero() {
+        const BUF_SIZE: libc::size_t = 0;
+        let mut buf = [0i8; BUF_SIZE];
+        let result = unsafe { write_cstr("".to_string(), buf.as_mut_ptr(), BUF_SIZE) };
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn write_one() {
+        const BUF_SIZE: libc::size_t = 1;
+        let mut buf = [0i8; BUF_SIZE];
+        let result = unsafe { write_cstr("".to_string(), buf.as_mut_ptr(), BUF_SIZE) };
+
+        assert_eq!(result, Some(BUF_SIZE - 1));
+        assert_eq!(buf, ['\0'].map(|c| c as i8));
+    }
+
+    #[test]
+    fn write_half() {
+        const BUF_SIZE: libc::size_t = 7;
+        let mut buf = [0i8; BUF_SIZE];
+        let result = unsafe { write_cstr("foo".to_string(), buf.as_mut_ptr(), BUF_SIZE) };
+
+        assert_eq!(result, Some(3));
+        assert_eq!(
+            buf,
+            ['f', 'o', 'o', '\0', '\0', '\0', '\0'].map(|c| c as i8)
+        );
+    }
+
+    #[test]
+    fn write_full() {
+        const BUF_SIZE: libc::size_t = 7;
+        let mut buf = [0i8; BUF_SIZE];
+        let result = unsafe { write_cstr("foobar".to_string(), buf.as_mut_ptr(), BUF_SIZE) };
+
+        assert_eq!(result, Some(6));
+        assert_eq!(buf, ['f', 'o', 'o', 'b', 'a', 'r', '\0'].map(|c| c as i8));
+    }
+
+    #[test]
+    fn write_overflow() {
+        const BUF_SIZE: libc::size_t = 4;
+        let mut buf = [0i8; BUF_SIZE];
+        let result = unsafe { write_cstr("overflow".to_string(), buf.as_mut_ptr(), BUF_SIZE) };
+
+        assert_eq!(result, None);
+        assert_eq!(buf, ['\0', '\0', '\0', '\0'].map(|c| c as i8));
+    }
+
+    #[test]
+    fn write_overwrite() {
+        const BUF_SIZE: libc::size_t = 4;
+        let mut buf = ['z', 'z', 'z', '\0'].map(|c| c as i8);
+        let result = unsafe { write_cstr("a".to_string(), buf.as_mut_ptr(), BUF_SIZE) };
+
+        assert_eq!(result, Some(1));
+        assert_eq!(buf, ['a', '\0', 'z', '\0'].map(|c| c as i8));
+    }
 }

--- a/arma-rs/src/testing.rs
+++ b/arma-rs/src/testing.rs
@@ -9,7 +9,7 @@ pub struct Extension {
     callback_queue: Arc<SegQueue<(String, String, Option<Value>)>>,
 }
 
-const BUFFER_SIZE: libc::size_t = 10240;
+const BUFFER_SIZE: libc::size_t = 10240; // The sized used by Arma 3 as of 2021-12-30
 
 #[derive(Debug, PartialEq, Eq)]
 /// Result of an event handler
@@ -36,9 +36,7 @@ impl Extension {
     #[must_use]
     /// Returns a context for simulating interactions with Arma
     pub fn context(&self) -> Context {
-        Context::new(self.callback_queue.clone()).with_buffer_size(
-            10240 - 8, // The sized used by Arma 3 as of 2021-12-30
-        )
+        Context::new(self.callback_queue.clone()).with_buffer_size(BUFFER_SIZE)
     }
 
     #[must_use]

--- a/arma-rs/tests/main.rs
+++ b/arma-rs/tests/main.rs
@@ -170,7 +170,7 @@ fn invalid_arg_type_position() {
 fn output_overflow() {
     let extension = Extension::build()
         .command("hello", |ctx: Context| -> String {
-            "X".repeat((ctx.buffer_len() / 8) + 1)
+            "X".repeat(ctx.buffer_len() + 1)
         })
         .finish()
         .testing();
@@ -182,7 +182,7 @@ fn output_overflow() {
 fn output_overflow_with_args() {
     let extension = Extension::build()
         .command("hello", |ctx: Context, item: char| -> String {
-            item.to_string().repeat((ctx.buffer_len() / 8) + 1)
+            item.to_string().repeat(ctx.buffer_len() + 1)
         })
         .finish()
         .testing();

--- a/arma-rs/tests/main.rs
+++ b/arma-rs/tests/main.rs
@@ -167,6 +167,30 @@ fn invalid_arg_type_position() {
 }
 
 #[test]
+fn filled_output() {
+    let extension = Extension::build()
+        .command("hello", |ctx: Context| -> String {
+            "X".repeat(ctx.buffer_len())
+        })
+        .finish()
+        .testing();
+    let (result, _) = unsafe { extension.call("hello", None) };
+    assert_eq!(result.len(), extension.context().buffer_len());
+}
+
+#[test]
+fn filled_output_with_args() {
+    let extension = Extension::build()
+        .command("hello", |ctx: Context, item: String| -> String {
+            item.repeat(ctx.buffer_len())
+        })
+        .finish()
+        .testing();
+    let (result, _) = unsafe { extension.call("hello", Some(vec![String::from('X')])) };
+    assert_eq!(result.len(), extension.context().buffer_len());
+}
+
+#[test]
 fn output_overflow() {
     let extension = Extension::build()
         .command("hello", |ctx: Context| -> String {
@@ -181,8 +205,8 @@ fn output_overflow() {
 #[test]
 fn output_overflow_with_args() {
     let extension = Extension::build()
-        .command("hello", |ctx: Context, item: char| -> String {
-            item.to_string().repeat(ctx.buffer_len() + 1)
+        .command("hello", |ctx: Context, item: String| -> String {
+            item.repeat(ctx.buffer_len() + 1)
         })
         .finish()
         .testing();


### PR DESCRIPTION
Fixes issue in `write_cstr` where it treats `buf_size` as the amount of bits even thought this represents the amount of bytes, mentioned in: https://github.com/BrettMayson/arma-rs/issues/24#issuecomment-1109522273. After merging this effectively allows for a 8 times bigger return.