### PR TITLE
Fix tuple's FromArma allows to many fields

### DIFF
--- a/arma-rs/src/value/from_arma.rs
+++ b/arma-rs/src/value/from_arma.rs
@@ -87,7 +87,7 @@ macro_rules! impl_from_arma_tuple {
                     .strip_suffix(']')
                     .ok_or_else(|| String::from("missing ']' at end of vec"))?;
                 let mut parts_iter = split_array(&source).into_iter();
-                Ok((
+                let ret = (
                     $(
                         {
                             let Some(n) = parts_iter.next() else {
@@ -96,7 +96,11 @@ macro_rules! impl_from_arma_tuple {
                             $t::from_arma(n.to_string().trim().to_string())?
                         }
                     ),*
-                ))
+                );
+                if parts_iter.next().is_some() {
+                    return Err(String::from("too many values in tuple"))
+                }
+                Ok(ret)
             }
         }
     };

--- a/arma-rs/src/value/from_arma.rs
+++ b/arma-rs/src/value/from_arma.rs
@@ -191,6 +191,8 @@ mod tests {
         );
         assert!(<(String, i32)>::from_arma(r#"["hello", 123"#.to_string()).is_err());
         assert!(<(String, i32)>::from_arma(r#""hello", 123"#.to_string()).is_err());
+        assert!(<(String, i32)>::from_arma(r#"["hello"]"#.to_string()).is_err());
+        assert!(<(String, i32)>::from_arma(r#"["hello", 123, 456]"#.to_string()).is_err());
     }
 
     #[test]
@@ -300,6 +302,8 @@ mod tests {
             vec![String::from("hello"), String::from("bye"),],
             <[String; 2]>::from_arma(r#"["hello","bye"]"#.to_string()).unwrap()
         );
+        assert!(<[String; 2]>::from_arma(r#"["hello"]"#.to_string()).is_err());
+        assert!(<[String; 2]>::from_arma(r#"["hello","bye","world"]"#.to_string()).is_err());
     }
 
     #[test]
@@ -321,6 +325,8 @@ mod tests {
         assert_eq!(
             1_227_700,
             <u32>::from_arma(r#"1.2277e+006"#.to_string()).unwrap()
-        )
+        );
+        assert!(<u32>::from_arma(r#"e-10"#.to_string()).is_err());
+        assert!(<u32>::from_arma(r#"1.0e"#.to_string()).is_err());
     }
 }


### PR DESCRIPTION
- Add an error for when tuple `FromArma` is given to many values
- Couple more error test cases