### PR TITLE
Set default version to 0.0.0

### DIFF
--- a/arma-rs/src/lib.rs
+++ b/arma-rs/src/lib.rs
@@ -78,7 +78,7 @@ impl Extension {
     /// Creates a new extension.
     pub fn build() -> ExtensionBuilder {
         ExtensionBuilder {
-            version: env!("CARGO_PKG_VERSION").to_string(),
+            version: std::env::var("CARGO_PKG_VERSION").unwrap_or_default(),
             group: Group::new(),
             state: State::default(),
             allow_no_args: false,

--- a/arma-rs/src/lib.rs
+++ b/arma-rs/src/lib.rs
@@ -78,7 +78,7 @@ impl Extension {
     /// Creates a new extension.
     pub fn build() -> ExtensionBuilder {
         ExtensionBuilder {
-            version: std::env::var("CARGO_PKG_VERSION").unwrap_or_default(),
+            version: String::from("0.0.0"),
             group: Group::new(),
             state: State::default(),
             allow_no_args: false,

--- a/arma-rs/tests/emulate.rs
+++ b/arma-rs/tests/emulate.rs
@@ -141,7 +141,7 @@ fn c_interface_full() {
 #[test]
 fn c_interface_builder() {
     let extension = Extension::build().finish();
-    assert_eq!(extension.version(), env!("CARGO_PKG_VERSION").to_string());
+    assert_eq!(extension.version(), String::from("0.0.0"));
     assert!(!extension.allow_no_args());
 
     let extension = Extension::build().version("1.0.0".to_string()).finish();


### PR DESCRIPTION
~~Get crate version at runtime instead of compile time so that the end users crate version is the default extension version~~
Set the default version to 0.0.0