### PR TITLE
Tidy up docs abit

### DIFF
--- a/arma-rs-proc/src/lib.rs
+++ b/arma-rs-proc/src/lib.rs
@@ -4,6 +4,8 @@ use quote::quote;
 use syn::ItemFn;
 
 #[proc_macro_attribute]
+/// Used to generate the necessary boilerplate for an Arma extension.
+/// It should be applied to a function that takes no arguments and returns an extension.
 pub fn arma(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let ast = syn::parse_macro_input!(item as ItemFn);
     let init = ast.sig.ident.clone();

--- a/arma-rs/src/command.rs
+++ b/arma-rs/src/command.rs
@@ -12,12 +12,14 @@ type HandlerFunc = Box<
     ) -> libc::c_int,
 >;
 
+#[doc(hidden)]
 /// A wrapper for `HandlerFunc`
 pub struct Handler {
     /// The function to call
     pub handler: HandlerFunc,
 }
 
+#[doc(hidden)]
 /// Create a new handler from a Factory
 pub fn fn_handler<C, I, R>(command: C) -> Handler
 where
@@ -37,6 +39,7 @@ where
     }
 }
 
+#[doc(hidden)]
 /// Execute a command
 pub trait Executor: 'static {
     /// # Safety
@@ -51,6 +54,7 @@ pub trait Executor: 'static {
     );
 }
 
+#[doc(hidden)]
 /// A factory for creating a command handler.
 /// Creates a handler from any function that optionally takes a context and up to 12 arguments.
 /// The arguments must implement `FromArma`

--- a/arma-rs/src/lib.rs
+++ b/arma-rs/src/lib.rs
@@ -44,6 +44,7 @@ pub mod testing;
 pub use testing::Result;
 
 #[cfg(all(windows, feature = "extension"))]
+#[doc(hidden)]
 /// Used by generated code to call back into Arma
 pub type Callback = extern "stdcall" fn(
     *const libc::c_char,
@@ -51,6 +52,7 @@ pub type Callback = extern "stdcall" fn(
     *const libc::c_char,
 ) -> libc::c_int;
 #[cfg(all(not(windows), feature = "extension"))]
+#[doc(hidden)]
 /// Used by generated code to call back into Arma
 pub type Callback =
     extern "C" fn(*const libc::c_char, *const libc::c_char, *const libc::c_char) -> libc::c_int;
@@ -104,11 +106,13 @@ impl Extension {
         self.allow_no_args
     }
 
+    #[doc(hidden)]
     /// Called by generated code, do not call directly.
     pub fn register_callback(&mut self, callback: Callback) {
         self.callback = Some(callback);
     }
 
+    #[doc(hidden)]
     /// Called by generated code, do not call directly.
     /// # Safety
     /// This function is unsafe because it interacts with the C API.
@@ -149,6 +153,7 @@ impl Extension {
         )
     }
 
+    #[doc(hidden)]
     /// Called by generated code, do not call directly.
     /// # Safety
     /// This function is unsafe because it interacts with the C API.
@@ -181,6 +186,7 @@ impl Extension {
         testing::Extension::new(self)
     }
 
+    #[doc(hidden)]
     /// Called by generated code, do not call directly.
     pub fn run_callbacks(&self) {
         let queue = self.callback_queue.clone();
@@ -320,6 +326,7 @@ impl ExtensionBuilder {
     }
 }
 
+#[doc(hidden)]
 /// Called by generated code, do not call directly.
 ///
 /// # Safety

--- a/arma-rs/src/lib.rs
+++ b/arma-rs/src/lib.rs
@@ -292,7 +292,7 @@ impl ExtensionBuilder {
     /// Example:
     /// ```sqf
     /// "my_ext" callExtension "my_func"
-    /// ``
+    /// ```
     pub const fn allow_no_args(mut self) -> Self {
         self.allow_no_args = true;
         self


### PR DESCRIPTION
Its a bit chaotic in the docs seeing a bunch of methods with:
> /// Called by generated code, do not call directly. 

I thought it might be nice to simply hide these and I also found a couple other nicknacks:
- Hide internal methods from documentation
- Add simple documentation to `arma` proc_macro
- Fix missing backtick in code example 