### PR TITLE
Function signature fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 *.dll
 Cargo.lock
 cov/
+.vscode/

--- a/arma-rs-proc/src/lib.rs
+++ b/arma-rs-proc/src/lib.rs
@@ -53,7 +53,7 @@ pub fn arma(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #[no_mangle]
-        pub unsafe extern #extern_type fn #versionfn(output: *mut arma_rs_libc::c_char, size: arma_rs_libc::size_t) -> arma_rs_libc::c_int {
+        pub unsafe extern #extern_type fn #versionfn(output: *mut arma_rs_libc::c_char, size: arma_rs_libc::c_int) -> arma_rs_libc::c_int {
             #ext_init
             if let Some(ext) = &RV_EXTENSION {
                 arma_rs::write_cstr(ext.version().to_string(), output, size);
@@ -62,7 +62,7 @@ pub fn arma(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #[no_mangle]
-        pub unsafe extern #extern_type fn #noargfn(output: *mut arma_rs_libc::c_char, size: arma_rs_libc::size_t, function: *mut arma_rs_libc::c_char) {
+        pub unsafe extern #extern_type fn #noargfn(output: *mut arma_rs_libc::c_char, size: arma_rs_libc::c_int, function: *mut arma_rs_libc::c_char) {
             #ext_init
             if let Some(ext) = &RV_EXTENSION {
                 if ext.allow_no_args() {
@@ -72,7 +72,7 @@ pub fn arma(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #[no_mangle]
-        pub unsafe extern #extern_type fn #argfn(output: *mut arma_rs_libc::c_char, size: arma_rs_libc::size_t, function: *mut arma_rs_libc::c_char, args: *mut *mut arma_rs_libc::c_char, arg_count: arma_rs_libc::c_int) -> arma_rs_libc::c_int {
+        pub unsafe extern #extern_type fn #argfn(output: *mut arma_rs_libc::c_char, size: arma_rs_libc::c_int, function: *mut arma_rs_libc::c_char, args: *mut *mut arma_rs_libc::c_char, arg_count: arma_rs_libc::c_int) -> arma_rs_libc::c_int {
             #ext_init
             if let Some(ext) = &RV_EXTENSION {
                 ext.handle_call(function, output, size, Some(args), Some(arg_count))

--- a/arma-rs/src/command.rs
+++ b/arma-rs/src/command.rs
@@ -6,7 +6,7 @@ type HandlerFunc = Box<
     dyn Fn(
         Context,
         *mut libc::c_char,
-        libc::size_t,
+        libc::c_int,
         Option<*mut *mut i8>,
         Option<libc::c_int>,
     ) -> libc::c_int,
@@ -29,7 +29,7 @@ where
         handler: Box::new(
             move |context: Context,
                   output: *mut libc::c_char,
-                  size: libc::size_t,
+                  size: libc::c_int,
                   args: Option<*mut *mut i8>,
                   count: Option<libc::c_int>|
                   -> libc::c_int {
@@ -48,7 +48,7 @@ pub trait Executor: 'static {
         &self,
         context: Context,
         output: *mut libc::c_char,
-        size: libc::size_t,
+        size: libc::c_int,
         args: Option<*mut *mut i8>,
         count: Option<libc::c_int>,
     );
@@ -66,7 +66,7 @@ pub trait Factory<A, R> {
         &self,
         context: Context,
         output: *mut libc::c_char,
-        size: libc::size_t,
+        size: libc::c_int,
         args: Option<*mut *mut i8>,
         count: Option<libc::c_int>,
     ) -> libc::c_int;
@@ -82,7 +82,7 @@ macro_rules! factory_tuple ({ $c: expr, $($param:ident)* } => {
             &self,
             context: Context,
             output: *mut libc::c_char,
-            size: libc::size_t,
+            size: libc::c_int,
             args: Option<*mut *mut i8>,
             count: Option<libc::c_int>,
         ) {
@@ -98,7 +98,7 @@ macro_rules! factory_tuple ({ $c: expr, $($param:ident)* } => {
         $($param: FromArma,)*
     {
         #[allow(non_snake_case)]
-        unsafe fn call(&self, _: Context, output: *mut libc::c_char, size: libc::size_t, args: Option<*mut *mut i8>, count: Option<libc::c_int>) -> libc::c_int {
+        unsafe fn call(&self, _: Context, output: *mut libc::c_char, size: libc::c_int, args: Option<*mut *mut i8>, count: Option<libc::c_int>) -> libc::c_int {
             let count = count.unwrap_or_else(|| 0);
             if count != $c {
                 return format!("2{}", count).parse::<libc::c_int>().unwrap();
@@ -155,7 +155,7 @@ macro_rules! factory_tuple ({ $c: expr, $($param:ident)* } => {
         $($param: FromArma,)*
     {
         #[allow(non_snake_case)]
-        unsafe fn call(&self, context: Context, output: *mut libc::c_char, size: libc::size_t, args: Option<*mut *mut i8>, count: Option<libc::c_int>) -> libc::c_int {
+        unsafe fn call(&self, context: Context, output: *mut libc::c_char, size: libc::c_int, args: Option<*mut *mut i8>, count: Option<libc::c_int>) -> libc::c_int {
             let count = count.unwrap_or_else(|| 0);
             if count != $c {
                 return format!("2{}", count).parse::<libc::c_int>().unwrap();
@@ -208,7 +208,7 @@ macro_rules! factory_tuple ({ $c: expr, $($param:ident)* } => {
 unsafe fn handle_output_and_return<R>(
     ret: R,
     output: *mut libc::c_char,
-    size: libc::size_t,
+    size: libc::c_int,
 ) -> libc::c_int
 where
     R: IntoExtResult + 'static,

--- a/arma-rs/src/group.rs
+++ b/arma-rs/src/group.rs
@@ -82,7 +82,7 @@ impl InternalGroup {
         context: Context,
         function: &str,
         output: *mut libc::c_char,
-        size: libc::size_t,
+        size: libc::c_int,
         args: Option<*mut *mut i8>,
         count: Option<libc::c_int>,
     ) -> libc::c_int {

--- a/arma-rs/src/testing.rs
+++ b/arma-rs/src/testing.rs
@@ -107,7 +107,7 @@ impl Extension {
             self.context(),
             function,
             output.as_mut_ptr(),
-            BUFFER_SIZE,
+            BUFFER_SIZE as libc::c_int,
             args_pointer.as_mut().map(Vec::as_mut_ptr),
             len,
         );


### PR DESCRIPTION
ArmA's function signature is:
`__attribute__((dllexport)) int RVExtensionArgs(char *output, int outputSize, const char *function, const char **argv, int argc);`
Note that the second argument is `int`. However, `arma-rs` uses `size_t`, which has different size in x64 (8 bytes vs. 4 for `size_t`). As a result, there is a stack overrun