### PR TITLE
Small FromArma impl fixes

### DIFF
--- a/arma-rs/src/value/from_arma.rs
+++ b/arma-rs/src/value/from_arma.rs
@@ -1,3 +1,5 @@
+use crate::Value;
+
 fn split_array(s: &str) -> Vec<String> {
     let mut nest = 0;
     let mut parts = Vec::new();
@@ -80,64 +82,47 @@ macro_rules! impl_from_arma_number {
 impl_from_arma_number!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize);
 
 macro_rules! impl_from_arma_tuple {
-    ($($t:ident),*) => {
+    { $c: expr, $($t:ident)* } => {
         impl<$($t),*> FromArma for ($($t),*)
         where
             $($t: FromArma),*
         {
-            #[allow(unused_assignments)]
-            #[allow(clippy::mixed_read_write_in_expression)]
             fn from_arma(s: String) -> Result<Self, String> {
-                let source = s
-                    .strip_prefix('[')
-                    .ok_or_else(|| String::from("missing '[' at start of vec"))?
-                    .strip_suffix(']')
-                    .ok_or_else(|| String::from("missing ']' at end of vec"))?;
-                let mut parts_iter = split_array(&source).into_iter();
-                let ret = (
-                    $(
-                        {
-                            let Some(n) = parts_iter.next() else {
-                                return Err(String::from("missing value in tuple"));
-                            };
-                            $t::from_arma(n.to_string().trim().to_string())?
-                        }
-                    ),*
-                );
-                if parts_iter.next().is_some() {
-                    return Err(String::from("too many values in tuple"))
-                }
-                Ok(ret)
+                let v: [Value; $c] = FromArma::from_arma(s)?;
+                let mut iter = v.iter();
+                Ok((
+                    $($t::from_arma(iter.next().unwrap().to_string())?),*
+                ))
             }
         }
     };
 }
 
-impl_from_arma_tuple!(A, B);
-impl_from_arma_tuple!(A, B, C);
-impl_from_arma_tuple!(A, B, C, D);
-impl_from_arma_tuple!(A, B, C, D, E);
-impl_from_arma_tuple!(A, B, C, D, E, F);
-impl_from_arma_tuple!(A, B, C, D, E, F, G);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y);
-impl_from_arma_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+impl_from_arma_tuple! { 2, A B }
+impl_from_arma_tuple! { 3, A B C }
+impl_from_arma_tuple! { 4, A B C D }
+impl_from_arma_tuple! { 5, A B C D E }
+impl_from_arma_tuple! { 6, A B C D E F }
+impl_from_arma_tuple! { 7, A B C D E F G }
+impl_from_arma_tuple! { 8, A B C D E F G H }
+impl_from_arma_tuple! { 9, A B C D E F G H I }
+impl_from_arma_tuple! { 10, A B C D E F G H I J }
+impl_from_arma_tuple! { 11, A B C D E F G H I J K }
+impl_from_arma_tuple! { 12, A B C D E F G H I J K L }
+impl_from_arma_tuple! { 13, A B C D E F G H I J K L M }
+impl_from_arma_tuple! { 14, A B C D E F G H I J K L M N }
+impl_from_arma_tuple! { 15, A B C D E F G H I J K L M N O }
+impl_from_arma_tuple! { 16, A B C D E F G H I J K L M N O P }
+impl_from_arma_tuple! { 17, A B C D E F G H I J K L M N O P Q }
+impl_from_arma_tuple! { 18, A B C D E F G H I J K L M N O P Q R }
+impl_from_arma_tuple! { 19, A B C D E F G H I J K L M N O P Q R S }
+impl_from_arma_tuple! { 20, A B C D E F G H I J K L M N O P Q R S T }
+impl_from_arma_tuple! { 21, A B C D E F G H I J K L M N O P Q R S T U }
+impl_from_arma_tuple! { 22, A B C D E F G H I J K L M N O P Q R S T U V }
+impl_from_arma_tuple! { 23, A B C D E F G H I J K L M N O P Q R S T U V W }
+impl_from_arma_tuple! { 24, A B C D E F G H I J K L M N O P Q R S T U V W X }
+impl_from_arma_tuple! { 25, A B C D E F G H I J K L M N O P Q R S T U V W X Y }
+impl_from_arma_tuple! { 26, A B C D E F G H I J K L M N O P Q R S T U V W X Y Z }
 
 impl<T> FromArma for Vec<T>
 where

--- a/arma-rs/src/value/from_arma.rs
+++ b/arma-rs/src/value/from_arma.rs
@@ -271,10 +271,6 @@ mod tests {
     #[test]
     fn parse_string() {
         assert_eq!(
-            String::from(""),
-            <String>::from_arma("\"\"".to_string()).unwrap()
-        );
-        assert_eq!(
             String::from("hello"),
             <String>::from_arma("hello".to_string()).unwrap()
         );
@@ -294,10 +290,6 @@ mod tests {
 
     #[test]
     fn parse_vec() {
-        assert_eq!(
-            vec![String::from(" ")],
-            <Vec<String>>::from_arma(r#"[" "]"#.to_string()).unwrap()
-        );
         assert_eq!(
             vec![String::from("hello"), String::from("bye"),],
             <Vec<String>>::from_arma(r#"["hello","bye"]"#.to_string()).unwrap()

--- a/arma-rs/src/value/from_arma.rs
+++ b/arma-rs/src/value/from_arma.rs
@@ -16,7 +16,10 @@ fn split_array(s: &str) -> Vec<String> {
             part.push(c);
         }
     }
-    parts.push(part.trim().to_string());
+    let part = part.trim().to_string();
+    if !part.is_empty() {
+        parts.push(part);
+    }
     parts
 }
 
@@ -143,15 +146,10 @@ where
             .strip_suffix(']')
             .ok_or_else(|| String::from("missing ']' at end of vec"))?;
         let parts = split_array(source);
-        if parts.len() == 1 && parts[0].is_empty() {
-            return Ok(Self::new());
-        }
-        let parts_iter = parts.iter();
-        let mut ret = Self::new();
-        for n in parts_iter {
-            ret.push(T::from_arma(n.trim().to_string())?);
-        }
-        Ok(ret)
+        parts.iter().try_fold(Self::new(), |mut acc, p| {
+            acc.push(T::from_arma(p.to_string())?);
+            Ok(acc)
+        })
     }
 }
 

--- a/arma-rs/src/value/into_arma.rs
+++ b/arma-rs/src/value/into_arma.rs
@@ -22,14 +22,12 @@ impl IntoArma for () {
 }
 
 macro_rules! impl_into_arma_tuple {
-    ($c:expr, $($t:ident),*) => {
+    { $c: expr, $($t:ident)* } => {
         seq_macro::seq!(N in 0..$c {
             impl<$($t),*> IntoArma for ($($t),*)
             where
                 $($t: IntoArma),*
             {
-                #[allow(unused_assignments)]
-                #[allow(clippy::mixed_read_write_in_expression)]
                 fn to_arma(&self) -> Value {
                     Value::Array(vec![
                         #(
@@ -41,29 +39,32 @@ macro_rules! impl_into_arma_tuple {
         });
     };
 }
-impl_into_arma_tuple!(2, A, B);
-impl_into_arma_tuple!(3, A, B, C);
-impl_into_arma_tuple!(4, A, B, C, D);
-impl_into_arma_tuple!(5, A, B, C, D, E);
-impl_into_arma_tuple!(6, A, B, C, D, E, F);
-impl_into_arma_tuple!(7, A, B, C, D, E, F, G);
-impl_into_arma_tuple!(8, A, B, C, D, E, F, G, H);
-impl_into_arma_tuple!(9, A, B, C, D, E, F, G, H, I);
-impl_into_arma_tuple!(10, A, B, C, D, E, F, G, H, I, J);
-impl_into_arma_tuple!(11, A, B, C, D, E, F, G, H, I, J, K);
-impl_into_arma_tuple!(12, A, B, C, D, E, F, G, H, I, J, K, L);
-impl_into_arma_tuple!(13, A, B, C, D, E, F, G, H, I, J, K, L, M);
-impl_into_arma_tuple!(14, A, B, C, D, E, F, G, H, I, J, K, L, M, N);
-impl_into_arma_tuple!(15, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
-impl_into_arma_tuple!(16, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
-impl_into_arma_tuple!(17, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q);
-impl_into_arma_tuple!(18, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R);
-impl_into_arma_tuple!(19, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S);
-impl_into_arma_tuple!(20, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T);
-impl_into_arma_tuple!(21, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U);
-impl_into_arma_tuple!(22, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V);
-impl_into_arma_tuple!(23, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W);
-impl_into_arma_tuple!(24, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X);
+
+impl_into_arma_tuple! { 2, A B }
+impl_into_arma_tuple! { 3, A B C }
+impl_into_arma_tuple! { 4, A B C D }
+impl_into_arma_tuple! { 5, A B C D E }
+impl_into_arma_tuple! { 6, A B C D E F }
+impl_into_arma_tuple! { 7, A B C D E F G }
+impl_into_arma_tuple! { 8, A B C D E F G H }
+impl_into_arma_tuple! { 9, A B C D E F G H I }
+impl_into_arma_tuple! { 10, A B C D E F G H I J }
+impl_into_arma_tuple! { 11, A B C D E F G H I J K }
+impl_into_arma_tuple! { 12, A B C D E F G H I J K L }
+impl_into_arma_tuple! { 13, A B C D E F G H I J K L M }
+impl_into_arma_tuple! { 14, A B C D E F G H I J K L M N }
+impl_into_arma_tuple! { 15, A B C D E F G H I J K L M N O }
+impl_into_arma_tuple! { 16, A B C D E F G H I J K L M N O P }
+impl_into_arma_tuple! { 17, A B C D E F G H I J K L M N O P Q }
+impl_into_arma_tuple! { 18, A B C D E F G H I J K L M N O P Q R }
+impl_into_arma_tuple! { 19, A B C D E F G H I J K L M N O P Q R S }
+impl_into_arma_tuple! { 20, A B C D E F G H I J K L M N O P Q R S T }
+impl_into_arma_tuple! { 21, A B C D E F G H I J K L M N O P Q R S T U }
+impl_into_arma_tuple! { 22, A B C D E F G H I J K L M N O P Q R S T U V }
+impl_into_arma_tuple! { 23, A B C D E F G H I J K L M N O P Q R S T U V W }
+impl_into_arma_tuple! { 24, A B C D E F G H I J K L M N O P Q R S T U V W X }
+impl_into_arma_tuple! { 25, A B C D E F G H I J K L M N O P Q R S T U V W X Y }
+impl_into_arma_tuple! { 26, A B C D E F G H I J K L M N O P Q R S T U V W X Y Z }
 
 #[cfg(test)]
 #[test]

--- a/arma-rs/src/value/into_arma.rs
+++ b/arma-rs/src/value/into_arma.rs
@@ -93,7 +93,11 @@ where
 #[cfg(test)]
 #[test]
 fn test_vec() {
-    assert_eq!(String::from("[1,2,3]"), vec![1, 2, 3].to_arma().to_string())
+    assert_eq!(String::from("[1,2,3]"), vec![1, 2, 3].to_arma().to_string());
+    assert_eq!(
+        String::from(r#"["hello","world"]"#),
+        vec!["hello", "world"].to_arma().to_string()
+    );
 }
 
 impl<T> IntoArma for &[T]
@@ -126,7 +130,11 @@ fn test_string() {
     assert_eq!(
         String::from("\"hello\""),
         String::from("hello").to_arma().to_string()
-    )
+    );
+    assert_eq!(
+        String::from(r#""hello ""john"".""#),
+        String::from(r#"hello "john"."#).to_arma().to_string()
+    );
 }
 
 impl IntoArma for &'static str {
@@ -436,11 +444,8 @@ mod tests {
 
     #[test]
     fn as_vec() {
-        let arr = Value::Array(vec![Value::String("hello".into())]);
-        let v = arr.as_vec().unwrap();
-        let first_value = v.get(0).unwrap();
-        assert!(first_value.is_string());
-        assert_eq!(first_value.to_string(), String::from("\"hello\""));
+        let array = Value::Array(vec![Value::String("hello".into())]);
+        assert_eq!(array.to_string(), r#"["hello"]"#.to_string());
     }
 
     #[test]

--- a/arma-rs/src/value/loadout/inventory_item.rs
+++ b/arma-rs/src/value/loadout/inventory_item.rs
@@ -153,12 +153,12 @@ mod tests {
 
     #[test]
     fn from_arma() {
-        let item = InventoryItem::from_arma("[test,1]".to_owned()).unwrap();
+        let item = InventoryItem::from_arma("[\"test\",1]".to_owned()).unwrap();
         assert_eq!(item.class(), "test");
         assert_eq!(item.count(), 1);
         assert_eq!(item.ammo(), None);
         assert!(!item.is_magazine());
-        let item = InventoryItem::from_arma("[test,1,1]".to_owned()).unwrap();
+        let item = InventoryItem::from_arma("[\"test\",1,1]".to_owned()).unwrap();
         assert_eq!(item.class(), "test");
         assert_eq!(item.count(), 1);
         assert_eq!(item.ammo(), Some(1));

--- a/arma-rs/src/value/mod.rs
+++ b/arma-rs/src/value/mod.rs
@@ -52,12 +52,12 @@ impl Display for Value {
 
 impl FromArma for Value {
     fn from_arma(s: String) -> Result<Self, String> {
-        match s.chars().next().unwrap() {
-            'n' => Ok(Self::Null),
-            't' | 'f' => Ok(Value::Boolean(<bool>::from_arma(s)?)),
-            '0'..='9' | '-' => Ok(Value::Number(<f64>::from_arma(s)?)),
-            '[' => Ok(Value::Array(<Vec<Value>>::from_arma(s)?)),
-            '"' => Ok(Value::String(<String>::from_arma(s)?)),
+        match s.chars().next() {
+            Some('n') => Ok(Self::Null),
+            Some('t') | Some('f') => Ok(Value::Boolean(<bool>::from_arma(s)?)),
+            Some('0'..='9') | Some('-') => Ok(Value::Number(<f64>::from_arma(s)?)),
+            Some('[') => Ok(Value::Array(<Vec<Value>>::from_arma(s)?)),
+            Some('"') => Ok(Value::String(<String>::from_arma(s)?)),
             _ => Err(format!("Invalid value: {s}")),
         }
     }


### PR DESCRIPTION
Various small things I noticed while working on the trait derive PR, decided to make it a separate PR
- Fix `split_array` returning a vec with an empty string when parsing a empty array
- Fix greedy string quote trimming; `"hello ""John"""` previously resulted in `hello ""John`
- Fix string didn't convert double quotes to single quote
- Remove unnecessary `trim` calls
- Simplify tuple impl by converting from a fixed sized array
- Implement IntoArma for tuples of up to 26 elements (IntoArma and FromArma didnt support the same count and thought they might as well match)