### PR TITLE
Update for `extern` changes in rust 1.89

### DIFF
--- a/arma-rs-proc/src/lib.rs
+++ b/arma-rs-proc/src/lib.rs
@@ -12,7 +12,7 @@ pub fn arma(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let ast = syn::parse_macro_input!(item as ItemFn);
     let init = ast.sig.ident.clone();
 
-    let extern_type = if cfg!(windows) { "stdcall" } else { "C" };
+    let extern_type = "system";
 
     let ext_init = quote! {
         if RV_EXTENSION.is_none() {

--- a/arma-rs/src/lib.rs
+++ b/arma-rs/src/lib.rs
@@ -49,21 +49,16 @@ pub mod testing;
 #[cfg(feature = "extension")]
 pub use testing::Result;
 
-#[cfg(all(windows, feature = "extension"))]
+#[cfg(all(feature = "extension"))]
 #[doc(hidden)]
 /// Used by generated code to call back into Arma
-pub type Callback = extern "stdcall" fn(
+pub type Callback = extern "system" fn(
     *const libc::c_char,
     *const libc::c_char,
     *const libc::c_char,
 ) -> libc::c_int;
-#[cfg(all(not(windows), feature = "extension"))]
-#[doc(hidden)]
-/// Used by generated code to call back into Arma
-pub type Callback =
-    extern "C" fn(*const libc::c_char, *const libc::c_char, *const libc::c_char) -> libc::c_int;
 /// Requests a call context from Arma
-pub type ContextRequest = unsafe extern "C" fn();
+pub type ContextRequest = unsafe extern "system" fn();
 
 #[cfg(feature = "extension")]
 enum CallbackMessage {
@@ -393,7 +388,7 @@ impl ExtensionBuilder {
     }
 }
 
-unsafe extern "C" fn empty_request_context() {}
+unsafe extern "system" fn empty_request_context() {}
 
 #[doc(hidden)]
 /// Called by generated code, do not call directly.

--- a/arma-rs/tests/emulate.rs
+++ b/arma-rs/tests/emulate.rs
@@ -10,10 +10,7 @@ mod extension {
 
     macro_rules! platform_extern {
         ($($func_body:tt)*) => {
-            #[cfg(windows)]
-            extern "stdcall" $($func_body)*
-            #[cfg(not(windows))]
-            extern "C" $($func_body)*
+            extern "system" $($func_body)*
         };
     }
 


### PR DESCRIPTION
> use of calling convention not supported on this target
  --> extension\src\lib.rs:16:1
   |
16 | #[arma]
   | ^^^^^^^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
   = note: this warning originates in the attribute macro `arma` (in Nightly builds, run with -Z macro-backtrace for more info)