### PR TITLE
call-context - work in debug

### DIFF
--- a/arma-rs/src/call_context/call.rs
+++ b/arma-rs/src/call_context/call.rs
@@ -40,6 +40,7 @@ impl RawArmaCallContext {
 
 pub trait StackRequest {}
 
+#[derive(Default)]
 pub struct WithStackTrace;
 impl StackRequest for WithStackTrace {}
 

--- a/arma-rs/src/call_context/manager.rs
+++ b/arma-rs/src/call_context/manager.rs
@@ -30,7 +30,7 @@ impl ArmaContextManager {
         // It can now be taken and sent to the Context
         self.state
             .replace(None)
-            .expect("Arma should've set the state")
+            .unwrap_or_default()
     }
 
     /// Replace the current ArmaCallContext with a new one


### PR DESCRIPTION
Fix #53 

in debug
- `call_context()` example returns
`["Unknown,Console,None,Singleplayer,0",0,0]`

- `stack_trace()` example still crashes
